### PR TITLE
Email req

### DIFF
--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -18,7 +18,7 @@
   <%= f.label :zipcode %>
   <%= f.text_field :zipcode %>
   <%= f.label :email %>
-  <%= f.text_field :email %>
+  <%= f.text_field :email, value: nil %>
   <%= f.label :password %>
   <%= f.password_field :password %>
   <%= f.label :password_confirmation %>

--- a/spec/features/users/registration_spec.rb
+++ b/spec/features/users/registration_spec.rb
@@ -80,18 +80,27 @@ RSpec.describe 'As a visitor' do
 
         visit root_path
         click_on "Register"
-        fill_in :Name, with: "name"
-        fill_in "Street address", with: "address"
-        fill_in :City, with: "city"
-        fill_in :State, with: "state"
-        fill_in :Zipcode, with: "zip"
+        fill_in :Name, with: "jalena"
+        fill_in "Street address", with: "123 address"
+        fill_in :City, with: "denver"
+        fill_in :State, with: "co"
+        fill_in :Zipcode, with: "12345"
         fill_in :Email, with: "email@email.com"
         fill_in :Password, with: "password"
         fill_in "Password confirmation", with: 'password'
 
         click_button "Register"
+        save_and_open_page
 
         expect(page).to have_content("Email has already been taken")
+        expect(page).to have_selector("input[value='jalena']")
+        expect(page).to have_selector("input[value='123 address']")
+        expect(page).to have_selector("input[value='denver']")
+        expect(page).to have_selector("input[value='co']")
+        expect(page).to have_selector("input[value='12345']")
+        expect(page).to_not have_selector("input[value='email@email.com']")
+
+
       end
     end
   end

--- a/spec/features/users/registration_spec.rb
+++ b/spec/features/users/registration_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 RSpec.describe 'As a visitor' do
   describe 'When I click on the register link in the nav bar' do
     it 'i see a form to register' do
-      visit root_path    
+      visit root_path
       click_on "Register"
       name = "hjk"
       address = "hjk"
@@ -61,6 +61,37 @@ RSpec.describe 'As a visitor' do
         click_button "Register"
 
         expect(page).to have_content("Password confirmation doesn't match Password")
+      end
+
+      it 'will not allow multiple users with the same email' do
+        visit root_path
+        click_on "Register"
+
+        fill_in :Name, with: "name"
+        fill_in "Street address", with: "address"
+        fill_in :City, with: "city"
+        fill_in :State, with: "state"
+        fill_in :Zipcode, with: "zip"
+        fill_in :Email, with: "email@email.com"
+        fill_in :Password, with: "password"
+        fill_in "Password confirmation", with: 'password'
+
+        click_button "Register"
+
+        visit root_path
+        click_on "Register"
+        fill_in :Name, with: "name"
+        fill_in "Street address", with: "address"
+        fill_in :City, with: "city"
+        fill_in :State, with: "state"
+        fill_in :Zipcode, with: "zip"
+        fill_in :Email, with: "email@email.com"
+        fill_in :Password, with: "password"
+        fill_in "Password confirmation", with: 'password'
+
+        click_button "Register"
+
+        expect(page).to have_content("Email has already been taken")
       end
     end
   end


### PR DESCRIPTION
@hsmitha26 / @erin-king / @stiehlrod 

Closes User Story 9 (#114) 
"As a visitor
When I visit the user registration page
If I fill out the registration form
But include an email address already in the system
Then I am returned to the registration page
My details are not saved and I am not logged in
The form is filled in with all previous data except the email field and password fields
I see a flash message telling me the email address is already in use"

- Created feature test for duplicate email submission
- Updated form to pass a nil value for email
- Updated form to display all error messages 
- All user registration tests passing
