### PR TITLE
adds story 6, restriction of user access #this

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,5 +1,9 @@
 class Admin::UsersController < ApplicationController
   def show
-    @admin = current_user
+    if current_admin
+      @admin = current_user
+    else
+      render_not_found
+    end
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,10 @@ class ApplicationController < ActionController::Base
 
   helper_method :current_user, :current_visitor, :current_admin, :current_merchant
 
+  def render_not_found
+    render :file => "#{Rails.root}/public/404.html", layout: false, status: :not_found
+  end
+  
   private
   def current_user
     @current_user ||= User.find(session[:user_id]) if session[:user_id]

--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -1,5 +1,7 @@
 class CartsController < ApplicationController
   def show
-
+    if current_admin || current_merchant
+      render_not_found
+    end
   end
 end

--- a/app/controllers/merchants_controller.rb
+++ b/app/controllers/merchants_controller.rb
@@ -10,7 +10,11 @@ class MerchantsController < ApplicationController
     @top_orders = Order.top_orders
   end
 
-  def show
-    @merchant = current_user
+    def show
+      if current_merchant
+        @merchant = current_user
+      else
+        render_not_found
+    end
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -20,7 +20,11 @@ class UsersController < ApplicationController
   end
 
   def show
-    @user = current_user
+    if current_user && current_user.role == 'user'
+      @user = current_user
+    else
+      render_not_found
+    end
   end
 
   def edit

--- a/spec/features/users/navigation_spec.rb
+++ b/spec/features/users/navigation_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe "navigation" do
       click_on "Cart"
       expect(current_path).to eq(cart_path)
     end
+
   end
 
   describe "visitor navigation" do
@@ -32,6 +33,16 @@ RSpec.describe "navigation" do
       expect(current_path).to eq(register_path)
 
       expect(page).to_not have_content("Logout")
+    end
+    it 'can restrict access for visitors' do
+      visit profile_path
+      expect(page.status_code).to eq(404)
+
+      visit dashboard_path
+      expect(page.status_code).to eq(404)
+
+      visit admin_dashboard_path
+      expect(page.status_code).to eq(404)
     end
   end
 
@@ -55,6 +66,17 @@ RSpec.describe "navigation" do
         expect(page).to have_content("Logged in as #{user.name}")
       end
     end
+    it 'can restrict access for registered user' do
+      user = create(:user)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+      visit dashboard_path
+      expect(page.status_code).to eq(404)
+
+      visit admin_dashboard_path
+      expect(page.status_code).to eq(404)
+    end
+
   end
 
   describe "As a merchant user" do
@@ -77,6 +99,19 @@ RSpec.describe "navigation" do
         expect(page).to have_content("Logged in as #{merchant_1.name}")
       end
     end
+    it 'can restrict access for merchant' do
+      merchant_1 = create(:merchant)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(merchant_1)
+
+      visit profile_path
+      expect(page.status_code).to eq(404)
+
+      visit admin_dashboard_path
+      expect(page.status_code).to eq(404)
+
+      visit cart_path
+      expect(page.status_code).to eq(404)
+    end
   end
 
   describe "As an admin user" do
@@ -98,6 +133,19 @@ RSpec.describe "navigation" do
 
         expect(page).to have_content("Logged in as #{admin.name}")
       end
+    end
+    it 'can restrict access for admin' do
+      admin = create(:admin)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
+
+      visit profile_path
+      expect(page.status_code).to eq(404)
+
+      visit dashboard_path
+      expect(page.status_code).to eq(404)
+
+      visit cart_path
+      expect(page.status_code).to eq(404)
     end
   end
 end


### PR DESCRIPTION
Users should see a 404 error under the following conditions:
- if visitors try to navigate to any /profile path
- if visitors try to navigate to any /dashboard path
- if visitors try to navigate to any /admin path
- if registered users try to navigate to any /dashboard path
- if registered users try to navigate to any /admin path
- if merchants try to navigate to any /profile path
- if merchants try to navigate to any /admin path
- if merchants try to navigate to any /cart path
- if admin users try to navigate to any /profile path
- if admin users try to navigate to any /dashboard path
- if admin users try to navigate to any /cart path

Co-authored-by: Jalena Taylor <45905026+jalena-penaligon@users.noreply.github.com>