### PR TITLE
Created view for empty cart

### DIFF
--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -2,6 +2,8 @@ class CartsController < ApplicationController
   def show
     if current_admin || current_merchant
       render_not_found
+    elsif session[:cart] == nil
+      flash[:notice] = "Your cart is empty."
     end
   end
 end

--- a/app/views/carts/show.html.erb
+++ b/app/views/carts/show.html.erb
@@ -1,0 +1,4 @@
+
+<% if session[:cart] != nil %>
+  <%= link_to "Clear Cart" %>
+<% end %>

--- a/spec/features/cart/cart_spec.rb
+++ b/spec/features/cart/cart_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe 'cart page', type: :feature do
+  context 'as a visitor or registered user' do
+    describe 'when I visit my cart /cart and there are no items' do
+      it 'shows a message that my cart is empty' do
+        visit cart_path
+
+        expect(page).to have_content("Your cart is empty.")
+        expect(page).to_not have_link("Clear Cart")
+      end
+    end
+  end
+end

--- a/spec/features/users/registration_spec.rb
+++ b/spec/features/users/registration_spec.rb
@@ -77,8 +77,9 @@ RSpec.describe 'As a visitor' do
         fill_in "Password confirmation", with: 'password'
 
         click_button "Register"
+        click_on "Logout"
 
-        visit root_path      
+        visit root_path
         click_on "Register"
         fill_in :Name, with: "jalena"
         fill_in "Street address", with: "123 address"


### PR DESCRIPTION
Closes User Story 22 (#97)
As a visitor or registered user
When I add NO items to my cart yet
And I visit my cart ("/cart")
I see a message that my cart is empty
I do NOT see the link to empty my cart

Co-authored-by: Erin King <44042415+erin-king@users.noreply.github.com>