### PR TITLE
Created admin user show page view

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -11,6 +11,7 @@ class Admin::UsersController < ApplicationController
   def show
     if current_admin
       @admin = current_user
+      @user = User.find(params[:id])
     else
       render_not_found
     end

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -1,1 +1,6 @@
-<h1>Logged in as <%= @admin.name %></h1>
+<h1><%= @user.name %></h1>
+<li><%= @user.email %></li>
+<li><%= @user.street_address %></li>
+<li><%= @user.city %></li>
+<li><%= @user.state %></li>
+<li><%= @user.zipcode %></li>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,5 +1,3 @@
-
-<%= flash.notice %>
 <h1>Logged in as <%= current_user.name %></h1>
 <li><%= current_user.email %></li>
 <li><%= current_user.street_address %></li>

--- a/spec/features/admins/user_show_spec.rb
+++ b/spec/features/admins/user_show_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe 'admin views a user show page', type: :feature do
+  context "as an admin" do
+    it 'shows all profile info without edit link' do
+      user = create(:user)
+      admin = create(:admin)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
+
+      visit root_path
+      click_link "Users"
+      click_link "#{user.name}"
+
+      expect(current_path).to eq(admin_user_path(user))
+
+      expect(page).to have_content(user.name)
+      expect(page).to have_content(user.email)
+      expect(page).to have_content(user.street_address)
+      expect(page).to have_content(user.city)
+      expect(page).to have_content(user.state)
+      expect(page).to have_content(user.zipcode)
+    end
+  end
+end
+
+
+# As an admin user
+# When I visit a user's profile page ("/admin/users/5")
+# I see the same information the user would see themselves
+# I do not see a link to edit their profile


### PR DESCRIPTION
Closes User Story 56

As an admin user
When I visit a user's profile page ("/admin/users/5")
I see the same information the user would see themselves
I do not see a link to edit their profile

Paired with Erin King