### PR TITLE
Story16, missing avg_fulfillment_time

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -4,4 +4,8 @@ class ItemsController < ApplicationController
     @most_popular = Item.items_sold(5, 'desc')
     @least_popular = Item.items_sold(5, 'asc')
   end
+
+  def show
+    @item = Item.find(params[:id])
+  end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -7,5 +7,6 @@ class ItemsController < ApplicationController
 
   def show
     @item = Item.find(params[:id])
+    @fulfillment_time = OrderItem.fulfillment_time(@item)
   end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -19,12 +19,12 @@ class Item < ApplicationRecord
        .order("items_qty #{order}")
        .limit(limit)
   end
-    # - the top 5 most popular items by quantity purchased, plus the quantity bought
-    # - the bottom 5 least popular items, plus the quantity bought
-    #
-    # "Popularity" is determined by total quantity of that item fulfilled
 
-  def self.least_popular
+  def average_item_fulfillment
+    # binding.pry
+    order_items
+    .select('avg(order_items.updated_at - order_items.created_at)as avg_fulfillment')
+    .where(fulfilled: true)
   end
 
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -20,11 +20,5 @@ class Item < ApplicationRecord
        .limit(limit)
   end
 
-  def average_item_fulfillment
-    # binding.pry
-    order_items
-    .select('avg(order_items.updated_at - order_items.created_at)as avg_fulfillment')
-    .where(fulfilled: true)
-  end
 
 end

--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -6,14 +6,23 @@ class OrderItem < ApplicationRecord
     fulfilled = true
   end
 
-  def fulfillment_time(item)
-    # binding.pry
-    if fulfilled?
-      select('sum(updated_at - created_at)')
-      .where("item_id = ?", item)
-      # .group(:item_id)
-    else
-      'n/a'
-    end
+  def self.fulfillment_time(item)
+    joins(:item)
+    .select('items.*, avg(order_items.updated_at - order_items.created_at) as avg_time')
+    .group('items.id')
+    .where("items.id = ?", item.id)
+    .limit(1)
+      # select items.id, avg(order_items.updated_at - order_items.created_at)as avg_time
+      # from order_items inner join items on order_items.item_id = items.id
+      # where items.id = 71 group by items.id;
   end
 end
+# def self.average_item_fulfillment(item)
+#   binding.pry
+#   self.select("items.*, avg(order_items.updated_at - order_items.created_at) as avg_time")
+#   .joins(:order_items)
+#   .where("order_items.fulfilled = true")
+#   .where("id = #{item}")
+#   .group(:id)
+#   .order(:id)
+# end

--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -1,4 +1,19 @@
 class OrderItem < ApplicationRecord
   belongs_to :order
   belongs_to :item
+
+  def fulfilled?
+    fulfilled = true
+  end
+
+  def fulfillment_time(item)
+    # binding.pry
+    if fulfilled?
+      select('sum(updated_at - created_at)')
+      .where("item_id = ?", item)
+      # .group(:item_id)
+    else
+      'n/a'
+    end
+  end
 end

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,0 +1,9 @@
+<h1><%=@item.name%></h1>
+<ul>
+  <li> <%= @item.description %> </li>
+  <li> <img src="<%= @item.image %>" /> </li>
+  <li> <%= @item.inventory %> </li>
+  <li> <%= @item.current_price %> </li>
+  <li> <%= @item.user.name %> </li>
+ <!-- <li>  @fulfillment_time.avg_time  </li> %> -->
+</ul>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -7,3 +7,4 @@
   <li> <%= @item.user.name %> </li>
  <!-- <li>  @fulfillment_time.avg_time  </li> %> -->
 </ul>
+<%= link_to "Add to Cart", cart_path %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -18,6 +18,7 @@ inactive_user_1 = create(:inactive_user)
 
 item_1 = create(:item, user: merchant_1)
 item_2 = create(:item, user: merchant_2)
+item_3 = create(:item, user: merchant_3)
 create_list(:item, 10, user: merchant_1)
 
 inactive_item_1 = create(:inactive_item, user: merchant_1)
@@ -28,28 +29,28 @@ rng = Random.new
 
 # pending order, none fulfilled
 order = create(:order, user: user)
-create(:order_item, order: order, item: item_1, price: 1, quantity: 1)
-create(:order_item, order: order, item: item_2, price: 2, quantity: 1)
+create(:order_item, order: order, item: item_1, order_price: 1, order_quantity: 1)
+create(:order_item, order: order, item: item_2, order_price: 2, order_quantity: 1)
 
 # pending order, partially fulfilled
 order = create(:order, user: user)
-create(:order_item, order: order, item: item_1, price: 1, quantity: 1)
-create(:fulfilled_order_item, order: order, item: item_2, price: 2, quantity: 1, created_at: (rng.rand(23)+1).days.ago, updated_at: rng.rand(23).hours.ago)
+create(:order_item, order: order, item: item_1, order_price: 1, order_quantity: 1)
+create(:fulfilled_order_item, order: order, item: item_2, order_price: 2, order_quantity: 1, created_at: (rng.rand(23)+1).days.ago, updated_at: rng.rand(23).hours.ago)
 
 # packaged order
 order = create(:packaged_order, user: user)
-create(:fulfilled_order_item, order: order, item: item_1, price: 1, quantity: 1, created_at: (rng.rand(3)+1).days.ago, updated_at: rng.rand(59).minutes.ago)
-create(:fulfilled_order_item, order: order, item: item_2, price: 2, quantity: 1, created_at: (rng.rand(23)+1).hour.ago, updated_at: rng.rand(59).minutes.ago)
+create(:fulfilled_order_item, order: order, item: item_1, order_price: 1, order_quantity: 1, created_at: (rng.rand(3)+1).days.ago, updated_at: rng.rand(59).minutes.ago)
+create(:fulfilled_order_item, order: order, item: item_2, order_price: 2, order_quantity: 1, created_at: (rng.rand(23)+1).hour.ago, updated_at: rng.rand(59).minutes.ago)
 
 # shipped order, cannot be cancelled
 order = create(:shipped_order, user: user)
-create(:fulfilled_order_item, order: order, item: item_1, price: 1, quantity: 1, created_at: (rng.rand(3)+1).days.ago, updated_at: rng.rand(59).minutes.ago)
-create(:fulfilled_order_item, order: order, item: item_2, price: 2, quantity: 1, created_at: (rng.rand(23)+1).hour.ago, updated_at: rng.rand(59).minutes.ago)
+create(:fulfilled_order_item, order: order, item: item_1, order_price: 1, order_quantity: 1, created_at: (rng.rand(3)+1).days.ago, updated_at: rng.rand(59).minutes.ago)
+create(:fulfilled_order_item, order: order, item: item_2, order_price: 2, order_quantity: 1, created_at: (rng.rand(23)+1).hour.ago, updated_at: rng.rand(59).minutes.ago)
 
 # cancelled order
 order = create(:cancelled_order, user: user)
-create(:order_item, order: order, item: item_2, price: 2, quantity: 1, created_at: (rng.rand(23)+1).hour.ago, updated_at: rng.rand(59).minutes.ago)
-create(:order_item, order: order, item: item_3, price: 3, quantity: 1, created_at: (rng.rand(23)+1).hour.ago, updated_at: rng.rand(59).minutes.ago)
+create(:order_item, order: order, item: item_2, order_price: 2, order_quantity: 1, created_at: (rng.rand(23)+1).hour.ago, updated_at: rng.rand(59).minutes.ago)
+create(:order_item, order: order, item: item_3, order_price: 3, order_quantity: 1, created_at: (rng.rand(23)+1).hour.ago, updated_at: rng.rand(59).minutes.ago)
 
 
 puts 'seed data finished'

--- a/spec/features/items/show_spec.rb
+++ b/spec/features/items/show_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+RSpec.describe 'all users' do
+  describe 'can visit an items show page' do
+    it 'has info about the item' do
+      merchant_1 = create(:merchant)
+      item_1 = create(:item, user: merchant_1)
+      user = create(:user)
+      order = create(:shipped_order, user: user)
+      order_item_1 = create(:fulfilled_order_item, order: order, item: item_1, order_price: 3.0, order_quantity: 6, created_at: 5.days.ago, updated_at: 1.days.ago)
+      order_item_2 = create(:fulfilled_order_item, order: order, item: item_1, order_price: 4.5, order_quantity: 2, created_at: 5.days.ago, updated_at: 2.days.ago)
+      order_item_3 = create(:fulfilled_order_item, order: order, item: item_1, order_price: 6.0, order_quantity: 1, created_at: 5.days.ago, updated_at: 3.days.ago)
+      order_item_4 = create(:fulfilled_order_item, order: order, item: item_1, order_price: 10.0, order_quantity: 5, created_at: 5.days.ago, updated_at: 4.days.ago)
+      order_item_5 = create(:fulfilled_order_item, order: order, item: item_1, order_price: 3.0, order_quantity: 2, created_at: 5.days.ago, updated_at: 5.days.ago)
+      order_item_6 = create(:fulfilled_order_item, order: order, item: item_1, order_price: 4.5, order_quantity: 1, created_at: 5.days.ago, updated_at: 3.days.ago)
+
+
+      visit item_path(item_1)
+
+      expect(page).to have_content(item_1.name)
+      expect(page).to have_content(item_1.description)
+      expect(page).to have_css("img[src*='#{item_1.image}']")
+      expect(page).to have_content(merchant_1.name)
+      expect(page).to have_content(item_1.inventory)
+      expect(page).to have_content(item_1.current_price)
+      # expect(page).to have_content("Average Fulfillment Time: 3")
+    end
+  end
+end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -39,5 +39,7 @@ RSpec.describe Item, type: :model do
       actual = Item.items_sold(5,'asc')
       expect(actual).to eq([@item_1,@item_2,@item_3,@item_4,@item_5])
     end
+    it 'can calc 'do
+    end
   end
 end

--- a/spec/models/order_item_spec.rb
+++ b/spec/models/order_item_spec.rb
@@ -1,10 +1,32 @@
 require 'rails_helper'
 
 RSpec.describe OrderItem, type: :model do
-
+  before :each do
+    @user = create(:user)
+    @merchant_1 = create(:merchant)
+    @merchant_2 = create(:merchant)
+    @item_1 = create(:item, user: @merchant_1)
+    @item_2 = create(:item, user: @merchant_2)
+    @order = create(:order, user: @user)
+    create(:order_item, order: @order, item: @item_1, order_price: 1, order_quantity: 1)
+    create(:order_item, order: @order, item: @item_2, order_price: 2, order_quantity: 1)
+    @order = create(:packaged_order, user: @user)
+    @oi_1 = create(:fulfilled_order_item, order: @order, item: @item_1, order_price: 1, order_quantity: 1, created_at: 3.5.days.ago, updated_at: 1.minutes.ago)
+    @oi_2 = create(:fulfilled_order_item, order: @order, item: @item_2, order_price: 2, order_quantity: 1, created_at: 4.5.days.ago, updated_at: 1.minutes.ago)
+  end
   describe 'relationships' do
     it { should belong_to :order }
     it { should belong_to :item }
   end
 
+  describe 'instance methods' do
+    xit 'can calc avg fulfillment time' do
+      actual = @oi_1.fulfillment_time(@item_1.id)
+      expect(actual).to eq(4)
+    end
+    xit 'can identify fulfilled order items' do
+      actual = @oi_1.fulfilled?
+      expect(actual).to eq(true)
+    end
+  end
 end


### PR DESCRIPTION
As any kind of user on the system
When I visit an item's show page from the items catalog
My URI route is something like "/items/18"
I see all information for this item, including:
- the name of the item
- the description of the item
- a larger image of the item
- the merchant name who sells the item
- how many of the item the merchant has in stock
- the merchant's current price for the item
- an average amount of time it takes this merchant to fulfill this item

If I am a visitor or regular user, I also see a link to add this item to my cart