### PR TITLE
User Story 25: Users Must Login or Register to Checkout

### DIFF
--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -18,7 +18,11 @@ class CartsController < ApplicationController
   end
 
   def destroy
-    session[:cart].clear
+    if params[:item_id] == nil
+      session[:cart].clear
+    else
+      session[:cart].delete(params[:item_id])
+    end
     redirect_to cart_path
   end
 end

--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -17,6 +17,14 @@ class CartsController < ApplicationController
     redirect_to items_path
   end
 
+  def update
+    # binding.pry
+    if params[:increment] == "add"
+      session[:cart][params[:item_id]]+=1
+      redirect_to cart_path
+    end
+  end
+
   def destroy
     if params[:item_id] == nil
       session[:cart].clear

--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -16,4 +16,9 @@ class CartsController < ApplicationController
     flash[:notice] = "#{@item.name} has been added to your cart!"
     redirect_to items_path
   end
+
+  def destroy
+    session[:cart].clear
+    redirect_to cart_path
+  end
 end

--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -21,8 +21,10 @@ class CartsController < ApplicationController
     # binding.pry
     if params[:increment] == "add"
       session[:cart][params[:item_id]]+=1
-      redirect_to cart_path
+    else params[:increment] == "subtract"
+      session[:cart][params[:item_id]] -= 1
     end
+    redirect_to cart_path
   end
 
   def destroy

--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -4,6 +4,8 @@ class CartsController < ApplicationController
       render_not_found
     elsif session[:cart] == nil
       flash[:notice] = "Your cart is empty."
+    # elsif session[:cart] != nil && current_user == nil
+    #   flash[:notice] = "You must login or register to checkout."
     end
   end
 

--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -18,9 +18,12 @@ class CartsController < ApplicationController
   end
 
   def update
-    # binding.pry
     if params[:increment] == "add"
-      session[:cart][params[:item_id]]+=1
+      item_total = (session[:cart][params[:item_id]])
+      inventory = params[:inventory].to_i
+      if item_total < inventory
+        session[:cart][params[:item_id]]+=1
+      end
     else params[:increment]
       item_total = (session[:cart][params[:item_id]] -= 1)
       if item_total == 0

--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -21,8 +21,11 @@ class CartsController < ApplicationController
     # binding.pry
     if params[:increment] == "add"
       session[:cart][params[:item_id]]+=1
-    else params[:increment] == "subtract"
-      session[:cart][params[:item_id]] -= 1
+    else params[:increment]
+      item_total = (session[:cart][params[:item_id]] -= 1)
+      if item_total == 0
+        session[:cart].delete(params[:item_id])
+      end
     end
     redirect_to cart_path
   end

--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -4,8 +4,6 @@ class CartsController < ApplicationController
       render_not_found
     elsif session[:cart] == nil
       flash[:notice] = "Your cart is empty."
-    # elsif session[:cart] != nil && current_user == nil
-    #   flash[:notice] = "You must login or register to checkout."
     end
   end
 

--- a/app/views/carts/show.html.erb
+++ b/app/views/carts/show.html.erb
@@ -1,3 +1,10 @@
+<% if session[:cart] != nil && current_user == nil %>
+  <section id="login-message">
+    "You must <%= link_to 'login', login_path %> or
+    <%= link_to 'register', register_path %> to checkout."
+  </section>
+<% end %>
+
 <% if session[:cart] != nil %>
   <% @cart.contents.each do |id| %>
     <section id="item-<%= id[0].to_i %>">

--- a/app/views/carts/show.html.erb
+++ b/app/views/carts/show.html.erb
@@ -8,7 +8,7 @@
     Merchant: <%= item.user.name %>
     Subtotal: $<%= number_with_precision(@cart.item_subtotal(item), precision: 2) %>
     <img src="<%= item.image %> width="100" height="100" ">
-    <%= link_to "Add One", cart_path(item_id: item.id, increment: "add"), method: :patch  %>
+    <%= link_to "Add One", cart_path(item_id: item.id, increment: "add", inventory: item.inventory), method: :patch  %>
     <%= link_to "Delete One", cart_path(item_id: item.id, increment: "subtract"), method: :patch  %>
     <%= link_to "Delete Item", cart_path(item_id: item.id), method: :delete  %>
     </section>

--- a/app/views/carts/show.html.erb
+++ b/app/views/carts/show.html.erb
@@ -13,5 +13,5 @@
 
   Total: $<%= number_with_precision(@cart.total_cost, precision: 2) %>
 
-  <%= link_to "Clear Cart" %>
+  <%= link_to "Clear Cart", @carts, method: :delete %>
 <% end %>

--- a/app/views/carts/show.html.erb
+++ b/app/views/carts/show.html.erb
@@ -1,7 +1,7 @@
 <% if session[:cart] != nil && current_user == nil %>
   <section id="login-message">
-    "You must <%= link_to 'login', login_path %> or
-    <%= link_to 'register', register_path %> to checkout."
+    You must <%= link_to 'login', login_path %> or
+    <%= link_to 'register', register_path %> to checkout.
   </section>
 <% end %>
 

--- a/app/views/carts/show.html.erb
+++ b/app/views/carts/show.html.erb
@@ -8,6 +8,8 @@
     Merchant: <%= item.user.name %>
     Subtotal: $<%= number_with_precision(@cart.item_subtotal(item), precision: 2) %>
     <img src="<%= item.image %> width="100" height="100" ">
+    <%= link_to "Add One", cart_path(item_id: item.id, increment: "add"), method: :patch  %>
+    <%# <%= link_to "Delete One", cart_path(item_id: item.id, increment: "subtract"), method: :patch  %> %>
     <%= link_to "Delete Item", cart_path(item_id: item.id), method: :delete  %>
     </section>
   <% end %>

--- a/app/views/carts/show.html.erb
+++ b/app/views/carts/show.html.erb
@@ -9,7 +9,7 @@
     Subtotal: $<%= number_with_precision(@cart.item_subtotal(item), precision: 2) %>
     <img src="<%= item.image %> width="100" height="100" ">
     <%= link_to "Add One", cart_path(item_id: item.id, increment: "add"), method: :patch  %>
-    <%# <%= link_to "Delete One", cart_path(item_id: item.id, increment: "subtract"), method: :patch  %> %>
+    <%= link_to "Delete One", cart_path(item_id: item.id, increment: "subtract"), method: :patch  %>
     <%= link_to "Delete Item", cart_path(item_id: item.id), method: :delete  %>
     </section>
   <% end %>

--- a/app/views/carts/show.html.erb
+++ b/app/views/carts/show.html.erb
@@ -8,6 +8,7 @@
     Merchant: <%= item.user.name %>
     Subtotal: $<%= number_with_precision(@cart.item_subtotal(item), precision: 2) %>
     <img src="<%= item.image %> width="100" height="100" ">
+    <%= link_to "Delete Item", cart_path(item_id: item.id), method: :delete  %>
     </section>
   <% end %>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -43,7 +43,7 @@
     </nav>
 
     <% flash.each do |type, message| %>
-      <p><%= message %></p>
+      <p class="flash"><%= message %></p>
     <% end %>
 
     <%= yield %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,6 +36,7 @@ Rails.application.routes.draw do
 
   get '/cart', to: 'carts#show', as: :cart
   get '/carts', to: 'carts#create', as: :carts
+  delete '/cart', to: 'carts#destroy'
 
   get '/dashboard', to: 'merchants#show'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,6 +34,7 @@ Rails.application.routes.draw do
   resources :items, only: [:index]
   resources :merchants, only: [:index]
 
+  patch '/cart', to: 'carts#update', as: :edit_cart
   get '/cart', to: 'carts#show', as: :cart
   get '/carts', to: 'carts#create', as: :carts
   delete '/cart', to: 'carts#destroy'

--- a/spec/features/cart/cart_spec.rb
+++ b/spec/features/cart/cart_spec.rb
@@ -122,6 +122,28 @@ RSpec.describe 'cart page', type: :feature do
         end
       end
 
+      describe "I see a link next to item to increment by one" do
+        it "increments that item by one" do
+          item_1 = create(:item, id: 1, current_price: 3.0)
+          visit item_path(item_1)
+          click_link "Add to Cart"
+
+          visit cart_path
+
+          click_link "Add One"
+
+          expect(page).to have_content("Quantity: 2")
+
+          click_link "Add One"
+
+          expect(page).to have_content("Quantity: 3")
+
+          click_link "Delete One"
+
+          expect(page).to have_content("Quantity: 2")
+        end
+      end
+
     end
   end
 end

--- a/spec/features/cart/cart_spec.rb
+++ b/spec/features/cart/cart_spec.rb
@@ -97,6 +97,31 @@ RSpec.describe 'cart page', type: :feature do
           expect(page).to have_content("Cart: 0")
         end
       end
+
+      describe "I see a link next to the item to delete it" do
+        it "deletes only that item" do
+          item_1 = create(:item, id: 1, current_price: 3.0)
+          visit item_path(item_1)
+          click_link "Add to Cart"
+
+          visit item_path(item_1)
+          click_link "Add to Cart"
+
+          item_2 = create(:item, id: 2, current_price: 4.5)
+          visit item_path(item_2)
+          click_link "Add to Cart"
+
+          visit cart_path
+
+          within "#item-#{item_2.id}" do
+            click_link "Delete Item"
+          end
+
+          expect(page).to_not have_content(item_2.name)
+          expect(page).to have_content(item_1.name)
+        end
+      end
+
     end
   end
 end

--- a/spec/features/cart/cart_spec.rb
+++ b/spec/features/cart/cart_spec.rb
@@ -71,7 +71,6 @@ RSpec.describe 'cart page', type: :feature do
 
           expect(page).to have_content("Total: $10.50")
           expect(page).to have_link("Clear Cart")
-
         end
       end
 
@@ -123,9 +122,12 @@ RSpec.describe 'cart page', type: :feature do
       end
 
       describe "I see a link next to item to increment by one" do
-        it "increments that item by one" do
-          item_1 = create(:item, id: 1, current_price: 3.0)
+        it "increments that item by one, but not above the merchant's inventory size" do
+          # merchant_1 = create(:merchant)
+          item_1 = create(:item, id: 1, current_price: 3.0, inventory: 2)
+
           visit item_path(item_1)
+
           click_link "Add to Cart"
 
           visit cart_path
@@ -134,12 +136,10 @@ RSpec.describe 'cart page', type: :feature do
 
           expect(page).to have_content("Quantity: 2")
 
+          visit cart_path
+
           click_link "Add One"
-
-          expect(page).to have_content("Quantity: 3")
-
-          click_link "Delete One"
-
+          
           expect(page).to have_content("Quantity: 2")
         end
       end
@@ -162,7 +162,6 @@ RSpec.describe 'cart page', type: :feature do
           expect(page).to_not have_content(item_1.name)
         end
       end
-
     end
   end
 end

--- a/spec/features/cart/cart_spec.rb
+++ b/spec/features/cart/cart_spec.rb
@@ -144,6 +144,25 @@ RSpec.describe 'cart page', type: :feature do
         end
       end
 
+      describe "I see a link next to item to decrement by one" do
+        it "decrements that item by one and removes item if decremented to zero" do
+          item_1 = create(:item, id: 1, current_price: 3.0)
+          visit item_path(item_1)
+          click_link "Add to Cart"
+          visit cart_path
+          click_link "Add One"
+          expect(page).to have_content("Quantity: 2")
+
+          click_link "Delete One"
+
+          expect(page).to have_content("Quantity: 1")
+
+          click_link "Delete One"
+
+          expect(page).to_not have_content(item_1.name)
+        end
+      end
+
     end
   end
 end

--- a/spec/features/cart/cart_spec.rb
+++ b/spec/features/cart/cart_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe 'cart page', type: :feature do
           visit cart_path
 
           click_link "Add One"
-          
+
           expect(page).to have_content("Quantity: 2")
         end
       end
@@ -160,6 +160,31 @@ RSpec.describe 'cart page', type: :feature do
           click_link "Delete One"
 
           expect(page).to_not have_content(item_1.name)
+        end
+      end
+    end
+
+    describe 'as a visitor' do
+      describe 'if I have items in my cart' do
+        it 'displays a message, with links, that you need to login or register' do
+          item_1 = create(:item, id: 1, current_price: 3.0)
+
+          visit item_path(item_1)
+          click_link "Add to Cart"
+
+          visit cart_path
+
+          within "#login-message" do
+            expect(page).to have_content("You must login or register to checkout.")
+
+            click_link "login"
+            expect(current_path).to eq(login_path)
+
+            visit cart_path
+
+            click_link "register"
+            expect(current_path).to eq(register_path)
+          end
         end
       end
     end

--- a/spec/features/cart/cart_spec.rb
+++ b/spec/features/cart/cart_spec.rb
@@ -74,20 +74,29 @@ RSpec.describe 'cart page', type: :feature do
 
         end
       end
+
+      describe 'when I click Clear Cart' do
+        it "clears my cart" do
+
+          item_1 = create(:item, id: 1, current_price: 3.0)
+          visit item_path(item_1)
+          click_link "Add to Cart"
+
+          visit item_path(item_1)
+          click_link "Add to Cart"
+
+          item_2 = create(:item, id: 2, current_price: 4.5)
+          visit item_path(item_2)
+          click_link "Add to Cart"
+
+          visit cart_path
+
+          click_link "Clear Cart"
+
+          expect(current_path).to eq(cart_path)
+          expect(page).to have_content("Cart: 0")
+        end
+      end
     end
   end
-
-
-#   As a visitor or registered user
-# When I have added items to my cart
-# And I visit my cart ("/cart")
-# I see all items I've added to my cart
-# And I see a link to empty my cart
-# Each item in my cart shows the following information:
-# - the name of the item
-# - a very small thumbnail image of the item
-# - the merchant I'm buying this item from
-# - the price of the item
-# - my desired quantity of the item
-# - a subtotal (price multiplied by quantity)
 end


### PR DESCRIPTION
Closes User Story 25 (#94 )
- Added a test to display message to visitors to login or register to checkout
- Updated view with conditional message

As a visitor
When I have items in my cart
And I visit my cart
I see information telling me I must register or log in to finish the checkout process
The word "register" is a link to the registration page
The words "log in" is a link to the login page