### PR TITLE
adds user story 32, admin dashboard orders

### DIFF
--- a/app/controllers/admin/admin_controller.rb
+++ b/app/controllers/admin/admin_controller.rb
@@ -1,0 +1,10 @@
+class Admin::AdminController < ApplicationController
+
+  def show
+    if current_admin
+      @orders = Order.sort_by_status
+    else
+      render_not_found
+    end
+  end
+end

--- a/app/models/cart.rb
+++ b/app/models/cart.rb
@@ -1,5 +1,5 @@
 class Cart
-  attr_accessor :contents
+  attr_reader :contents
 
   def initialize(initial_contents)
     @contents = initial_contents

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -18,13 +18,13 @@ class Order < ApplicationRecord
 
   def self.sort_by_status
     self.order(:status, id: :asc)
+  end
 
   def generate_order_items(cart)
     cart.contents.each do |id_quantity|
       item = cart.find_item(id_quantity)
       OrderItem.create(order_id: self.id, item_id: item.id, order_price: item.current_price, order_quantity: id_quantity.last)
     end
-
   end
 
   def total_quantity

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -3,7 +3,8 @@ class Order < ApplicationRecord
   has_many :items, through: :order_items
   belongs_to :user
 
-  enum status: ['pending', 'packaged', 'shipped', 'cancelled']
+  enum status:['packaged','pending','shipped','cancelled']
+  #['pending', 'packaged', 'shipped', 'cancelled']
 
   def self.top_orders
     joins(:order_items)
@@ -12,6 +13,10 @@ class Order < ApplicationRecord
     .group(:id)
     .order('total_quantity DESC')
     .limit(3)
+  end
+
+  def self.sort_by_status
+    self.order(:status, id: :asc)
   end
 
   def total_quantity

--- a/app/views/admin/admin/show.html.erb
+++ b/app/views/admin/admin/show.html.erb
@@ -1,0 +1,11 @@
+<h1>Admin Dashboard</h1>
+  <% @orders.each do |order| %>
+  <section class="orders">
+    <div id="order-<%=order.id%>">
+      <%= link_to "#{order.user.name}", admin_user_path(order.user.id) %>
+      <%= order.id %>
+      <%= order.created_at %>
+      <%= order.status %>
+    </div>
+  </section>
+  <% end %>

--- a/app/views/merchants/orders/show.html.erb
+++ b/app/views/merchants/orders/show.html.erb
@@ -14,7 +14,7 @@
     <div class="fulfill-item-<%=order_item.id%>">
         <% if order_item.fulfilled == false %>
             Status: not fulfilled
-            <%= link_to "Fulfill", fulfill_order_item_path(order_item.id) %>
+            <%= link_to "Fulfill", fulfill_order_item_path(order_item.id), method: :patch %>
         <% else %>
             Status: fulfilled
         <% end %>

--- a/app/views/merchants/show.html.erb
+++ b/app/views/merchants/show.html.erb
@@ -13,8 +13,8 @@
   <% @merchant.items.each do |item| %>
     <% item.order_items.each do |order_item| %>
 
-      Order ID: <%= link_to "#{order_item.order_id}", profile_order_path(@merchant, order_item.order_id) %>
-
+      Order ID: <%= link_to "#{order_item.order_id}", dashboard_order_path(order_item.order_id) %>
+<!--@merchant,  -->
       Order Created: <%= order_item.created_at %>
       Quantity: <%= order_item.order_quantity %>
       Price: <%= order_item.order_price %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,7 +25,7 @@ Rails.application.routes.draw do
   get '/profile', to: 'users#show'
   resources :users, only:  [:index, :create, :update]
 
-  resources :users, only: [:destroy], as: :profile do
+  resources :users, only: [:destroy], as: :profile do #send key value of order_id, change to scope, remove destroy
     resources :orders, only: [:index, :show]
   end
 
@@ -33,13 +33,13 @@ Rails.application.routes.draw do
 
   scope :dashboard, as: :dashboard do
     get '/orders/:id', to: 'merchants/orders#show', as: :order
+    get '/orders/', to: 'merchants/orders#index', as: :orders
   end
 
   get '/dashboard', to: 'merchants#show'
   resources :merchants, only: [:index, :show]
-  get '/order_items/:id', to: 'merchants/order_items#update'#, as: :fulfill_order_item
-  put '/order_items/:id', to: 'merchants/order_items#update', as: :fulfill_order_item
-
+  # get '/order_items/:id', to: 'merchants/order_items#update'#, as: :fulfill_order_item
+  patch '/order_items/:id', to: 'merchants/order_items#update', as: :fulfill_order_item
 
   patch '/cart', to: 'carts#update', as: :edit_cart
   get '/cart', to: 'carts#show', as: :cart
@@ -47,13 +47,11 @@ Rails.application.routes.draw do
   delete '/cart', to: 'carts#destroy'
 
 
-  get 'admin/dashboard', to: 'users#show', as: :admin_dashboard
-
   namespace :admin do
     resources :users, only: [:index, :show]
-    resources :merchants, only: [:index]
+    resources :merchants, only: [:index, :show]
+    get 'dashboard', to: 'admin#show', as: :dashboard
+    # resources :orders, only: [:index]
   end
-
-  get 'admin/merchants/:id', to: 'admin/merchants#show', as: :admin_merchant
 
 end

--- a/spec/features/admins/orders/index_spec.rb
+++ b/spec/features/admins/orders/index_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+RSpec.describe "As an admin user" do
+  before :each do
+    @user = create(:user)
+    @user_2 = create(:user)
+    @admin= create(:user, role:2)
+    @merchant_1, @merchant_2 = create_list(:merchant, 2)
+    @item_1 = create(:item, user: @merchant_1, inventory: 1)
+    @item_2 = create(:item, user: @merchant_2)
+    @item_3 = create(:item, user: @merchant_1, inventory: 0)
+    # shipped order, cannot be cancelled
+    @order_1 = create(:shipped_order, user: @user)
+    @order_item_1 = create(:fulfilled_order_item, order: @order_1, item: @item_1, order_price: 1, order_quantity: 1, created_at: 4.days.ago, updated_at: 1.days.ago)
+    @order_item_2 = create(:fulfilled_order_item, order: @order_1, item: @item_2, order_price: 2, order_quantity: 1, created_at: 4.days.ago, updated_at: 1.days.ago)
+    @order_2 = create(:shipped_order, user: @user_2)
+    @order_item_3 = create(:fulfilled_order_item, order: @order_2, item: @item_1, order_price: 1, order_quantity: 1, created_at: 4.days.ago, updated_at: 1.days.ago)
+    # pending order, none fulfilled
+    @order_3 = create(:order, user: @user_2)
+    @order_item_4 = create(:order_item, order: @order_3, item: @item_1, order_price: 1, order_quantity: 1)
+    @order_item_5 = create(:order_item, order: @order_3, item: @item_2, order_price: 2, order_quantity: 1)
+    # packaged order
+    @order_5 = create(:packaged_order, user: @user)
+    @order_item_8 = create(:fulfilled_order_item, order: @order_5, item: @item_2, order_price: 1, order_quantity: 1, created_at: 5.days.ago, updated_at: 1.days.ago)
+    @order_item_9 = create(:fulfilled_order_item, order: @order_5, item: @item_3, order_price: 2, order_quantity: 1, created_at: 5.days.ago, updated_at: 1.days.ago)
+    # cancelled order
+    @order_6 = create(:cancelled_order, user: @user)
+    create(:order_item, order: @order_6, item: @item_2, order_price: 2, order_quantity: 1, created_at: 5.days.ago, updated_at: 1.days.ago)
+    create(:order_item, order: @order_6, item: @item_3, order_price: 3, order_quantity: 1, created_at: 5.days.ago, updated_at: 1.days.ago)
+
+end
+  describe "When I log into my dashboard, /admin/dashboard" do
+    it 'can see all orders in the system' do
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@admin)
+
+      visit admin_dashboard_path
+
+      within "#order-#{@order_1.id}" do
+        expect(page).to have_content(@user.name)
+        expect(page).to have_content(@order_1.id)
+        expect(page).to have_content(@order_1.created_at)
+      end
+      within "#order-#{@order_2.id}" do
+        expect(page).to have_content(@user_2.name)
+        expect(page).to have_content(@order_2.id)
+        expect(page).to have_content(@order_2.created_at)
+      end
+      expect(page.all(".orders")[0]).to have_content("#{@order_5.id}")
+      expect(page.all(".orders")[1]).to have_content("#{@order_3.id}")
+      expect(page.all(".orders")[2]).to have_content("#{@order_1.id}")
+      expect(page.all(".orders")[3]).to have_content("#{@order_2.id}")
+      expect(page.all(".orders")[4]).to have_content("#{@order_6.id}")
+
+      within "#order-#{@order_2.id}" do
+        click_on "#{@user_2.name}"
+      end
+      expect(current_path).to eq(admin_user_path(@user_2.id))
+    end
+  end
+end

--- a/spec/features/merchants/show_spec.rb
+++ b/spec/features/merchants/show_spec.rb
@@ -41,8 +41,7 @@ RSpec.describe "When a merchant visits dashboard show page", type: :feature do
 
   it "I can see pending orders for items I sell" do
 
-    visit dashboard_path
-
+    visit dashboard_path #'merchants#show'
 
     expect(page).to have_content(@order.id)
     expect(page).to have_content(@order.created_at)
@@ -51,7 +50,10 @@ RSpec.describe "When a merchant visits dashboard show page", type: :feature do
 
 
     click_on "#{@order.id}"
-    expect(current_path).to eq(profile_order_path(@merchant_1, @order))
+    # expect(current_path).to eq(profile_order_path(@merchant_1, @order))
+    # - the ID of the order, which is a link to the order show page ("/dashboard/orders/15")
+    expect(current_path).to eq(dashboard_order_path(@order.id))
+    expect(page).to have_content(@order.user.name )
 
   end
 end


### PR DESCRIPTION
Co-authored-by: Jalena Taylor <45905026+jalena-penaligon@users.noreply.github.com>

As an admin user
When I log into my dashboard, "/admin/dashboard"
Then I see all orders in the system.
For each order I see the following information:

- user who placed the order, which links to admin view of user profile
- order id
- date the order was created

Orders are sorted by "status" in this order:

- packaged
- pending
- shipped
- cancelled