### PR TITLE
adds story33

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -10,8 +10,7 @@ class OrdersController < ApplicationController
 
   def ship
     order = Order.find(params[:id])
-    order.update!(status: "shipped")
-    # order.status =
+    order.update(status: "shipped")
     redirect_to admin_dashboard_path
   end
 

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -8,4 +8,18 @@ class OrdersController < ApplicationController
     @order = Order.find(params[:id])
   end
 
+  def ship
+    order = Order.find(params[:id])
+    order.update!(status: "shipped")
+    # order.status =
+    redirect_to admin_dashboard_path
+  end
+
+  def cancel
+    @order = Order.find(params[:id])
+    @order.status = 3
+    @order.save
+    redirect_to admin_dashboard_path
+  end
+
 end

--- a/app/views/admin/admin/show.html.erb
+++ b/app/views/admin/admin/show.html.erb
@@ -6,6 +6,11 @@
       <%= order.id %>
       <%= order.created_at %>
       <%= order.status %>
+        <% if order.status == "packaged" %>
+            <%= link_to "Ship",  ship_path(order), method: :patch%>
+        <% elsif order.status != "cancelled"  && order.status != "shipped"%>
+            <%= link_to "Cancel", cancel_path(order), method: :patch %>
+        <% end %>
     </div>
   </section>
   <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,12 +40,13 @@ Rails.application.routes.draw do
   resources :merchants, only: [:index, :show]
   # get '/order_items/:id', to: 'merchants/order_items#update'#, as: :fulfill_order_item
   patch '/order_items/:id', to: 'merchants/order_items#update', as: :fulfill_order_item
-
   patch '/cart', to: 'carts#update', as: :edit_cart
   get '/cart', to: 'carts#show', as: :cart
   get '/carts', to: 'carts#create', as: :carts
   delete '/cart', to: 'carts#destroy'
 
+  patch '/order/:id', to: 'orders#ship', as: :ship
+  patch '/order/:id', to: 'orders#cancel', as: :cancel
 
   namespace :admin do
     resources :users, only: [:index, :show]

--- a/spec/features/admins/orders/index_spec.rb
+++ b/spec/features/admins/orders/index_spec.rb
@@ -55,5 +55,32 @@ end
       end
       expect(current_path).to eq(admin_user_path(@user_2.id))
     end
+
+    it 'I see any "packaged" orders ready to ship' do
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@admin)
+      user = create(:user)
+      merchant_1, merchant_2 = create_list(:merchant, 2)
+      item_1 = create(:item, user: merchant_1, inventory: 1)
+      item_2 = create(:item, user: merchant_2)
+      # packaged order
+      order = create(:packaged_order, user: user, status: 0)
+      order_item_8 = create(:fulfilled_order_item, order: order, item: item_2, order_price: 1, order_quantity: 1, created_at: 5.days.ago, updated_at: 1.days.ago)
+      order_item_9 = create(:fulfilled_order_item, order: order, item: item_1, order_price: 2, order_quantity: 1, created_at: 5.days.ago, updated_at: 1.days.ago)
+      visit admin_dashboard_path
+        # within (page.all(".orders")[1]) do#{}"#order-#{order.id}"
+        within ("#order-#{order.id}") do
+          expect(order.status).to eq("packaged")
+          click_on "Ship"
+          expect(current_path).to eq(admin_dashboard_path)
+        end
+          # binding.pry
+          within "#order-#{order.id}" do
+            order = Order.find(order.id)
+            expect(order.status).to eq("shipped")
+            expect(page).to have_content("shipped")
+            # expect(order.status).to eq("shipped")
+            expect(page).to_not have_content("Cancel")
+          end
+      end
+    end
   end
-end

--- a/spec/features/admins/orders/index_spec.rb
+++ b/spec/features/admins/orders/index_spec.rb
@@ -67,18 +67,15 @@ end
       order_item_8 = create(:fulfilled_order_item, order: order, item: item_2, order_price: 1, order_quantity: 1, created_at: 5.days.ago, updated_at: 1.days.ago)
       order_item_9 = create(:fulfilled_order_item, order: order, item: item_1, order_price: 2, order_quantity: 1, created_at: 5.days.ago, updated_at: 1.days.ago)
       visit admin_dashboard_path
-        # within (page.all(".orders")[1]) do#{}"#order-#{order.id}"
         within ("#order-#{order.id}") do
           expect(order.status).to eq("packaged")
           click_on "Ship"
           expect(current_path).to eq(admin_dashboard_path)
         end
-          # binding.pry
           within "#order-#{order.id}" do
             order = Order.find(order.id)
             expect(order.status).to eq("shipped")
             expect(page).to have_content("shipped")
-            # expect(order.status).to eq("shipped")
             expect(page).to_not have_content("Cancel")
           end
       end


### PR DESCRIPTION
story33
As an admin user
When I log into my dashboard, "/admin/dashboard"
Then I see any "packaged" orders ready to ship.
Next to each order I see a button to "ship" the order.
When I click that button for an order, the status of that order changes to "shipped"
And the user can no longer "cancel" the order.