### PR TITLE
User Story 48, Merchant adds an item

### DIFF
--- a/app/controllers/merchants/items_controller.rb
+++ b/app/controllers/merchants/items_controller.rb
@@ -1,7 +1,33 @@
 class Merchants::ItemsController < ApplicationController
 
   def index
+    if current_merchant
+      @merchant = current_user
+    else
+      render_not_found
+    end
+  end
 
+  def new
+    @merchant = User.find(params[:merchant_id])
+    @item = Item.new
+  end
+
+  def create
+    @merchant = User.find(params[:user_id].to_i)
+    @item = @merchant.items.create(item_params)
+    if @item.save
+      flash[:notice] = "You successfully added #{@item.name} to your shop."
+      redirect_to dashboard_items_path
+    else
+      render :new
+    end
+  end
+
+  private
+
+  def item_params
+    params.require(:item).permit(:name, :description, :current_price, :inventory, :image, :active)
   end
 
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -2,7 +2,9 @@ class Item < ApplicationRecord
   has_many :order_items
   has_many :orders, through: :order_items
   belongs_to :user
-  validates_presence_of :name
+  validates_presence_of :name, :description
+  validates :current_price, numericality: { greater_than: 0 }
+  validates :inventory, numericality: { greater_than: -1 }
 
   def self.active_items_by_merchant
         select('users.name as merchant_name, items.*')

--- a/app/views/merchants/items/index.html.erb
+++ b/app/views/merchants/items/index.html.erb
@@ -1,13 +1,12 @@
 <h1>Merchant's Items Page</h1>
-<p><%= link_to "Add New Item" %></p>
-
-<% current_user.items.each do |item| %>
+<p><%= link_to "Add New Item", dashboard_items_new_path(merchant_id: @merchant.id) %></p>
+<% @merchant.items.each do |item| %>
 <section id="item-<%=item.id%>">
   <ul>
-    <li><%= item.id %></li>
-    <li><%= item.name %></li>
-    <li><%= item.current_price %></li>
-    <li><%= item.inventory %></li>
+    <li>ID: <%= item.id %></li>
+    <li>Name: <%= item.name %></li>
+    <li>Price: <%= item.current_price %></li>
+    <li>Inventory: <%= item.inventory %></li>
     <li><%= link_to "Edit Item" %></li>
       <% if item.active? %>
         <%= button_to "Disable" %>

--- a/app/views/merchants/items/new.html.erb
+++ b/app/views/merchants/items/new.html.erb
@@ -1,0 +1,25 @@
+<h1>Add a New Item</h1>
+
+<% if @item.errors.any? %>
+  <ul class="errors">
+    <% @item.errors.full_messages.each do |message| %>
+      <li class="error"><%= message %></li>
+    <% end %>
+  </ul>
+<% end %>
+
+<%= form_for [@merchant, @item], action: :create, :url => dashboard_items_path do |f| %>
+  <%= f.label :name %>
+  <%= f.text_field :name %><br />
+  <%= f.label :description %>
+  <%= f.text_field :description %><br />
+  <%= f.label :inventory %>
+  <%= f.number_field :inventory %><br />
+  <%= f.label :current_price %>
+  <%= f.number_field :current_price, class: :text_field, step: :any %><br />
+  <%= f.label :image %>
+  <%= f.text_field :image %><br />
+  <%= f.hidden_field :active, value: true %>
+  <%= hidden_field_tag "user_id", @merchant.id %>
+  <%= f.submit "Add New Item" %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,6 +33,8 @@ Rails.application.routes.draw do
   scope :dashboard, as: :dashboard do
     get '/orders/:id', to: 'merchants/orders#show', as: :order
     get '/items', to: 'merchants/items#index'
+    get '/items/new', to: 'merchants/items#new'
+    post '/items', to: 'merchants/items#create'
     get '/orders/', to: 'merchants/orders#index', as: :orders
   end
 

--- a/spec/features/merchants/items/new_spec.rb
+++ b/spec/features/merchants/items/new_spec.rb
@@ -1,0 +1,132 @@
+require 'rails_helper'
+
+RSpec.describe 'merchant new item', type: :feature do
+  context "As a merchant" do
+    describe "when I visit my items page" do
+      it "has a link to create a new item" do
+        merchant = create(:merchant, id: 1)
+        item_1 = create(:item, user: merchant)
+        allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(merchant)
+
+        visit dashboard_items_path
+
+        click_link("Add New Item")
+
+        expect(current_path).to eq(dashboard_items_new_path)
+
+        fill_in :Name, with: "Zucchini"
+        fill_in :Description, with: "Organic Zucchini Squash, 1.5 lb"
+        fill_in :Inventory, with: 17
+        fill_in "Current price", with: 2
+        fill_in :Image, with: "https://images.unsplash.com/photo-1499125650409-2c437d5cca77?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1789&q=80"
+
+        click_button("Add New Item")
+
+        item_2 = Item.last
+        merchant = User.find(1)
+        allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(merchant)
+
+        expect(current_path).to eq(dashboard_items_path)
+
+        expect(page).to have_content("You successfully added #{item_2.name} to your shop.")
+
+        visit dashboard_items_path
+        within "#item-#{item_2.id}" do
+          expect(page).to have_content("ID: #{item_2.id}")
+          expect(page).to have_content(item_2.name)
+          expect(page).to have_content("Price: #{item_2.current_price}")
+          expect(page).to have_content("Inventory: #{item_2.inventory}")
+          expect(page).to have_css("img[src*='#{item_2.image}']")
+          expect(page).to have_button("Disable")
+        end
+      end
+
+      it "will not add items with missing info" do
+        merchant = create(:merchant, id: 1)
+        item_1 = create(:item, user: merchant)
+        allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(merchant)
+
+        visit dashboard_items_path
+
+        click_link("Add New Item")
+
+        expect(current_path).to eq(dashboard_items_new_path)
+
+        fill_in :Image, with: "https://images.unsplash.com/photo-1499125650409-2c437d5cca77?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1789&q=80"
+
+        click_button("Add New Item")
+
+        expect(page).to have_content("Name can't be blank")
+        expect(page).to have_content("Description can't be blank")
+        expect(page).to have_content("Inventory is not a number")
+        expect(page).to have_content("Current price is not a number")
+      end
+
+      it "will use a default image if no image is added" do
+        merchant = create(:merchant, id: 1)
+        item_1 = create(:item, user: merchant)
+        allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(merchant)
+
+        visit dashboard_items_path
+
+        click_link("Add New Item")
+
+        fill_in :Name, with: "Zucchini"
+        fill_in :Description, with: "Organic Zucchini Squash, 1.5 lb"
+        fill_in :Inventory, with: 17
+        fill_in "Current price", with: 2
+
+        click_button("Add New Item")
+
+        item_2 = Item.last
+        merchant = User.find(1)
+        allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(merchant)
+
+        expect(current_path).to eq(dashboard_items_path)
+
+        expect(page).to have_content("You successfully added #{item_2.name} to your shop.")
+
+        visit dashboard_items_path
+        within "#item-#{item_2.id}" do
+          expect(page).to have_css("img[src*='#{item_2.image}']")
+        end
+      end
+
+      it "will not add an item if price is below 0.01" do
+        merchant = create(:merchant, id: 1)
+        item_1 = create(:item, user: merchant)
+        allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(merchant)
+
+        visit dashboard_items_path
+
+        click_link("Add New Item")
+
+        fill_in :Name, with: "Zucchini"
+        fill_in :Description, with: "Organic Zucchini Squash, 1.5 lb"
+        fill_in :Inventory, with: 17
+        fill_in "Current price", with: 0
+
+        click_button("Add New Item")
+        expect(page).to have_content("Current price must be greater than 0")
+      end
+
+      it "will not add an item if inventory is less than 1" do
+        merchant = create(:merchant, id: 1)
+        item_1 = create(:item, user: merchant)
+        allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(merchant)
+
+        visit dashboard_items_path
+
+        click_link("Add New Item")
+
+        fill_in :Name, with: "Zucchini"
+        fill_in :Description, with: "Organic Zucchini Squash, 1.5 lb"
+        fill_in :Inventory, with: -1
+        fill_in "Current price", with: 0.99
+
+        click_button("Add New Item")
+        expect(page).to have_content("Inventory must be greater than -1")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes User Story 48
- Created test for merchants to add new items
- Added routes for merchants/items new & update 
- Updated MerchantsItems controller to only allow merchants to view a dashboard through /dashboard
- Created view for merchants to add a new item
- All tests passing

As a merchant
When I visit my items page
And I click on the link to add a new item
My URI route should be "/dashboard/items/new"
I see a form where I can add new information about an item, including:
- the name of the item, which cannot be blank
- a description for the item, which cannot be blank
- a thumbnail image URL string, which CAN be left blank
- a price which must be greater than $0.00
- my current inventory count of this item which is 0 or greater

When I submit valid information and save the form
I am taken back to my items page
I see a flash message indicating my new item is saved
I see the new item on the page, and it is enabled and available for sale
If I left the image field blank, I see a placeholder image for the thumbnail