### PR TITLE
Completes user story 57

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -16,4 +16,16 @@ class Admin::UsersController < ApplicationController
       render_not_found
     end
   end
+
+  def upgrade
+    if current_admin
+      user = User.find(params[:id])
+      user.role = 'merchant'
+      user.save
+      flash[:notice] = "User has been upgraded."
+      redirect_to admin_merchant_path(user)
+    else
+      render_not_found
+    end
+  end
 end

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -4,3 +4,5 @@
 <li><%= @user.city %></li>
 <li><%= @user.state %></li>
 <li><%= @user.zipcode %></li>
+
+<li><%= button_to "Upgrade", admin_user_upgrade_path(@user), method: :patch %></li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -52,6 +52,7 @@ Rails.application.routes.draw do
     resources :users, only: [:index, :show]
     resources :merchants, only: [:index, :show]
     get 'dashboard', to: 'admin#show', as: :dashboard
+    patch '/users/:id/upgrade', to: 'users#upgrade', as: :user_upgrade
     # resources :orders, only: [:index]
   end
 

--- a/spec/features/admins/user_show_spec.rb
+++ b/spec/features/admins/user_show_spec.rb
@@ -20,11 +20,33 @@ RSpec.describe 'admin views a user show page', type: :feature do
       expect(page).to have_content(user.state)
       expect(page).to have_content(user.zipcode)
     end
+
+    it "can make a User a merchant" do
+      user = create(:user)
+      admin = create(:admin)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
+
+      visit admin_user_path(user)
+
+      click_button "Upgrade"
+      expect(current_path).to eq(admin_merchant_path(user))
+
+      expect(page).to have_content("User has been upgraded.")
+    end
+
+    it "user can now login as merchant" do
+      user = create(:user)
+      admin = create(:admin)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
+
+      visit admin_user_path(user)
+
+      click_button "Upgrade"
+      merchant = User.find(user.id)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(merchant)
+
+      visit dashboard_path
+      expect(page.status_code).to eq(200)
+    end
   end
 end
-
-
-# As an admin user
-# When I visit a user's profile page ("/admin/users/5")
-# I see the same information the user would see themselves
-# I do not see a link to edit their profile


### PR DESCRIPTION
Completes user story 57

As an admin user
When I visit a user's profile page ("/admin/users/5")
I see a link to "upgrade" the user's account to become a merchant
When I click on that link
I am redirected to ("/admin/merchants/5") because the user is now a merchant
And I see a flash message indicating the user has been upgraded
The next time this user logs in they are now a merchant
Only admins can reach any route necessary to upgrade the user to merchant status

Adds:
- feature test (admin/user_show_spec)
- route path admin_user_upgrade_path
- upgrade action in admin/users controller.