### PR TITLE
User Story 60: Redirect admin from merchant to user show page

### DIFF
--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -1,5 +1,11 @@
 class Admin::MerchantsController < ApplicationController
+
+  before_action :current_admin
+
   def show
     @merchant = User.find(params[:id])
+    if @merchant.role != 'merchant'
+      redirect_to admin_user_path(params[:id])
+    end
   end
 end

--- a/spec/features/admins/merchants/show_spec.rb
+++ b/spec/features/admins/merchants/show_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe 'As an admin' do
+  describe 'If I visit a merchant dashboard, but that merchant is a regular user' do
+    it 'I am redirected to the appropriate user profile page' do
+      user = create(:user, id: 7)
+      admin = create(:admin)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
+
+      visit admin_merchant_path(user.id)
+
+      expect(current_path).to eq(admin_user_path(user.id))
+
+    end
+  end
+end


### PR DESCRIPTION
As an admin user
If I visit a merchant dashboard, but that merchant is a regular user
Then I am redirected to the appropriate user profile page.

-Add test to check redirect (imagining someone trying to manually enter a merchant user id for a a regular user). 

- Add conditional statement to Admin::MerchantsController#show to redirect non-merchants to amdin user show page.

- All tests passing.