### PR TITLE
User Story 50 & 51: Merchant Can Edit an Item

### DIFF
--- a/app/controllers/merchants/items_controller.rb
+++ b/app/controllers/merchants/items_controller.rb
@@ -24,10 +24,34 @@ class Merchants::ItemsController < ApplicationController
     end
   end
 
+  def edit
+    @merchant = User.find(params[:merchant_id])
+    @item = Item.find(params[:id])
+  end
+
+  def update
+    @merchant = User.find(params[:id].to_i)
+    @item = Item.find(params[:id])
+    if @item.update(update_params)
+      flash[:notice] =  "Your item has been updated."
+      redirect_to dashboard_items_path
+    else
+      render :edit
+    end
+  end
+
   private
 
   def item_params
     params.require(:item).permit(:name, :description, :current_price, :inventory, :image, :active)
+  end
+
+  def update_params
+    update_params = params.require(:item).permit(:name, :description, :current_price, :inventory, :image, :active)
+    if update_params[:image] == ""
+      update_params[:image] = "http://kriokrush.com.au/wp-content/uploads/2016/12/ComingSoon.jpg"
+    end
+    update_params
   end
 
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -11,7 +11,7 @@
 <% @items.each do |item| %>
   <h3><%= link_to "#{item.name}", item_path(item) %></h3>
   <%= item.merchant_name %>
-    Price: <%= item.current_price %>
+    Price: <%= number_to_currency(item.current_price) %>
     Inventory: <%= item.inventory %>
     <%= link_to image_tag(item.image), item_path(item) %>
 <% end %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,10 +1,10 @@
 <h1><%=@item.name%></h1>
 <ul>
-  <li> <%= @item.description %> </li>
+  <li>Description: <%= @item.description %> </li>
   <li> <img src="<%= @item.image %>" /> </li>
-  <li> <%= @item.inventory %> </li>
-  <li> <%= @item.current_price %> </li>
-  <li> <%= @item.user.name %> </li>
-  <li> <%=@fulfillment_time %>  </li> 
+  <li>Inventory: <%= @item.inventory %> </li>
+  <li>Price: <%= number_to_currency(@item.current_price) %> </li>
+  <li>Merchant: <%= @item.user.name %> </li>
+  <li>Average Fulfillment Time: <%=@fulfillment_time %>  </li>
 </ul>
 <%= link_to "Add to Cart", carts_path(item_id: @item.id) %>

--- a/app/views/merchants/items/edit.html.erb
+++ b/app/views/merchants/items/edit.html.erb
@@ -1,0 +1,25 @@
+<h1>Edit Item</h1>
+
+<% if @item.errors.any? %>
+  <ul class="errors">
+    <% @item.errors.full_messages.each do |message| %>
+      <li class="error"><%= message %></li>
+    <% end %>
+  </ul>
+<% end %>
+
+<%= form_for [@merchant, @item], action: :edit, :url => dashboard_item_edit_path(@item) do |f| %>
+  <%= f.label :name %>
+  <%= f.text_field :name %><br />
+  <%= f.label :description %>
+  <%= f.text_field :description %><br />
+  <%= f.label :inventory %>
+  <%= f.number_field :inventory %><br />
+  <%= f.label :current_price %>
+  <%= f.number_field :current_price, class: :text_field, step: :any %><br />
+  <%= f.label :image %>
+  <%= f.text_field :image %><br />
+  <%= f.hidden_field :active, value: true %>
+  <%= hidden_field_tag "user_id", @merchant.id %>
+  <%= f.submit "Update Item" %>
+<% end %>

--- a/app/views/merchants/items/index.html.erb
+++ b/app/views/merchants/items/index.html.erb
@@ -5,9 +5,9 @@
   <ul>
     <li>ID: <%= item.id %></li>
     <li>Name: <%= item.name %></li>
-    <li>Price: <%= item.current_price %></li>
+    <li>Price: <%= number_to_currency(item.current_price) %></li>
     <li>Inventory: <%= item.inventory %></li>
-    <li><%= link_to "Edit Item" %></li>
+    <li><%= link_to "Edit Item", dashboard_item_edit_path(item, merchant_id: item.user.id) %></li>
       <% if item.active? %>
         <%= button_to "Disable", dashboard_toggle_item_path(item), method: :patch %>
       <% else %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,7 +38,8 @@ Rails.application.routes.draw do
 
     get '/items/new', to: 'merchants/items#new'
     post '/items', to: 'merchants/items#create'
-
+    get '/items/:id/edit', to: 'merchants/items#edit', as: :item_edit
+    patch '/items/:id/edit', to: 'merchants/items#update', as: :item_update
     get '/orders/', to: 'merchants/orders#index', as: :orders
   end
 

--- a/spec/features/merchants/items/edit_spec.rb
+++ b/spec/features/merchants/items/edit_spec.rb
@@ -1,0 +1,122 @@
+require 'rails_helper'
+
+RSpec.describe 'merchant edit items', type: :feature do
+  context "As a merchant" do
+    describe "when I visit my items page" do
+      it "has a link to edit an existing item" do
+        merchant = create(:merchant, id: 1)
+        item = merchant.items.create(id: 1, name: "Apple", image: "https://images.unsplash.com/photo-1478004521390-655bd10c9f43?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=668&q=80", description: "Gala Apple, One Medium. Organic, natural, can be stored in refrigerators.", inventory: 15, current_price: 0.50, active: true)
+        allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(merchant)
+
+        visit dashboard_items_path
+
+        click_link("Edit Item")
+        expect(current_path).to eq(dashboard_item_edit_path(item))
+        expect(page).to have_selector("input[value='#{item.name}']")
+        expect(page).to have_selector("input[value='#{item.description}']")
+        expect(page).to have_selector("input[value='#{item.current_price}']")
+        expect(page).to have_selector("input[value='#{item.inventory}']")
+        expect(page).to have_selector("input[value='#{item.image}']")
+        fill_in :Description, with: "Gala Apple. One large."
+        fill_in :Inventory, with: 45
+
+        click_button("Update Item")
+
+        expect(current_path).to eq(dashboard_items_path)
+        expect(page).to have_content("Your item has been updated.")
+
+        merchant = User.find(1)
+        item = Item.find(1)
+        allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(merchant)
+
+        visit dashboard_items_path
+        expect(page).to have_content("Inventory: 45")
+        expect(page).to have_button("Disable")
+
+        visit item_path(item)
+        expect(page).to have_content("Gala Apple. One large.")
+      end
+
+      it "will not let you leave name or description blank" do
+        merchant = create(:merchant, id: 1)
+        item = merchant.items.create(id: 1, name: "Apple", image: "https://images.unsplash.com/photo-1478004521390-655bd10c9f43?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=668&q=80", description: "Gala Apple, One Medium. Organic, natural, can be stored in refrigerators.", inventory: 15, current_price: 0.50, active: true)
+        allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(merchant)
+
+        visit dashboard_items_path
+
+        click_link("Edit Item")
+
+        fill_in :Description, with: ""
+        fill_in :Name, with: ""
+
+        click_button("Update Item")
+
+        expect(page).to have_content("Name can't be blank")
+        expect(page).to have_content("Description can't be blank")
+      end
+
+      it "will not let you drop price below 0.01 or inventory below 0" do
+        merchant = create(:merchant, id: 1)
+        item = merchant.items.create(id: 1, name: "Apple", image: "https://images.unsplash.com/photo-1478004521390-655bd10c9f43?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=668&q=80", description: "Gala Apple, One Medium. Organic, natural, can be stored in refrigerators.", inventory: 15, current_price: 0.50, active: true)
+        allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(merchant)
+
+        visit dashboard_items_path
+
+        click_link("Edit Item")
+
+        fill_in :Inventory, with: -5
+        fill_in "Current price", with: 0
+
+        click_button("Update Item")
+
+        expect(page).to have_content("Inventory must be greater than -1")
+        expect(page).to have_content("Current price must be greater than 0")
+      end
+
+      it "will use the default image if image is removed" do
+        merchant = create(:merchant, id: 1)
+        item = merchant.items.create(id: 1, name: "Apple", image: "https://images.unsplash.com/photo-1478004521390-655bd10c9f43?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=668&q=80", description: "Gala Apple, One Medium. Organic, natural, can be stored in refrigerators.", inventory: 15, current_price: 0.50, active: true)
+        allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(merchant)
+
+        visit dashboard_items_path
+
+        click_link("Edit Item")
+
+        fill_in :Image, with: ""
+
+        click_button("Update Item")
+
+        merchant = User.find(1)
+        item = Item.find(1)
+        allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(merchant)
+
+        visit dashboard_items_path
+
+        within "#item-#{item.id}" do
+          expect(page).to have_css("img[src*='http://kriokrush.com.au/wp-content/uploads/2016/12/ComingSoon.jpg']")
+        end
+      end
+
+      it "will repopulate my form data if field(s) are missing" do
+        merchant = create(:merchant, id: 1)
+        item = merchant.items.create(id: 1, name: "Apple", image: "https://images.unsplash.com/photo-1478004521390-655bd10c9f43?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=668&q=80", description: "Gala Apple, One Medium. Organic, natural, can be stored in refrigerators.", inventory: 15, current_price: 0.50, active: true)
+        allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(merchant)
+
+        visit dashboard_items_path
+
+        click_link("Edit Item")
+
+        fill_in :Name, with: ""
+        expect(page).to have_selector("input[value='#{item.description}']")
+        expect(page).to have_selector("input[value='#{item.current_price}']")
+        expect(page).to have_selector("input[value='#{item.inventory}']")
+        expect(page).to have_selector("input[value='#{item.image}']")
+
+        click_button("Update Item")
+
+        expect(page).to have_content("Name can't be blank")
+
+      end
+    end
+  end
+end

--- a/spec/features/merchants/items/new_spec.rb
+++ b/spec/features/merchants/items/new_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe 'merchant new item', type: :feature do
         within "#item-#{item_2.id}" do
           expect(page).to have_content("ID: #{item_2.id}")
           expect(page).to have_content(item_2.name)
-          expect(page).to have_content("Price: #{item_2.current_price}")
+          expect(page).to have_content("Price: $2.00")
           expect(page).to have_content("Inventory: #{item_2.inventory}")
           expect(page).to have_css("img[src*='#{item_2.image}']")
           expect(page).to have_button("Disable")


### PR DESCRIPTION
Closes User Stories 50 & 51
- Creates test for edit functionality
- Adds edit/update route for merchant/items
- Adds labels to views for readability 
- Adds edit/update methods in MerchantItems controller

Story 50:
As a merchant
When I visit my items page
And I click the edit button or link next to any item
Then I am taken to a form similar to the 'new item' form
My URI route will be "/dashboard/items/15/edit" (if the item's ID was 15)
The form is re-populated with all of this item's information
I can change any information, but all of the rules for adding a new item still apply:
- name and description cannot be blank
- price cannot be less than $0.00
- inventory must be 0 or greater

When I submit the form
I am taken back to my items page
I see a flash message indicating my item is updated
I see the item's new information on the page, and it maintains its previous enabled/disabled state
If I left the image field blank, I see a placeholder image for the thumbnail

Story 51: 
As a merchant
When I try to edit an existing item
If any of my data is incorrect or missing (except image)
Then I am returned to the form
I see one or more flash messages indicating each error I caused
All fields are re-populated with my previous data