### PR TITLE
Fixes Upgrade to Merchant for admin-user index page.

### DIFF
--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -2,6 +2,6 @@
   <section id="user-<%=user.id%>">
     <%= link_to user.name, admin_user_path(user) %> <br />
     Date Registered: <%= user.created_at.to_s(:long) %>
-    <%= button_to "Upgrade to Merchant" %>
+    <%= button_to "Upgrade to Merchant", admin_user_upgrade_path(user), method: :patch %>
   </section>
 <% end %>


### PR DESCRIPTION
- When a logged in admin clicked on "Upgrade to Merchant" from users index page, the re-route did not exist.
-  added path to re-route when admin upgrades user to merchant in admin/user_index.html.erb